### PR TITLE
Remove verification request in on_message

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -457,10 +457,6 @@ async def on_message(message: discord.Message):
     serv = message.channel
     if message.guild is not None:
         serv = message.guild
-    res = await mg_client.verify(serv.id)
-    if not res:
-        await message.channel.send(PLZ_VERIFY)
-        return
     await mg_client.add_server(serv)
     if message.attachments:
         verify_result = await mg_client.verify(serv.id)


### PR DESCRIPTION
# What this PR does

Removes the verification request in on_message - we now only send a verification request on command use.

- [x] I have tested this code
- [x] I have requested a review from dhrumilp15 or another dev.

# Are there related Issues?
An issue was reported in the discord server in which any message in a channel would receive the verification request.
# Other Comments
