### PR TITLE
Past search for files in other channels

### DIFF
--- a/bot_commands.py
+++ b/bot_commands.py
@@ -260,7 +260,8 @@ async def past_search(
     # fcounter = 0
     # mcounter = 0
     # start = time.time()
-    matched_messages = ctx.channel.history(limit=int(1e9), before=kwargs.get("before"), after=kwargs.get("after"))
+    onii_chan = kwargs.get("channel", ctx.channel)
+    matched_messages = onii_chan.history(limit=int(1e9), before=kwargs.get("before"), after=kwargs.get("after"))
     # avg_attachment_time = 0
     # avg_match_time = 0
     # avg_join_time = 0


### PR DESCRIPTION
# What this PR does
Allows you to pass channel to /search to perform a past search in a channel from another channel. This approaches the issue of searching past files in all of a server's channels.

- [x] I have tested this code
- [x] I have requested a review from dhrumilp15 or another dev.

# Are there related Issues?
Issue reported in the discord server.

# Other Comments
Nope